### PR TITLE
Add Globally Normalized Reader blog entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,12 @@
 
         <section id="main_content">
 
-          
+<h3> 
+<a href="http://svail.github.io/GloballyNormalizedReader/" Onclick="_gaq.push(['trackEvent','Outbound’,'GloballyNormalizedReader',’svail.github.io/GloballyNormalizedReader',true]);" >Globally Normalized Reader</a>
+</h3>
+<p><strong>Date:</strong> August 23, 2017<br>
+<strong>Authors:</strong> Jonathan Raiman, John Miller<br>
+We present the Globally Normalized Reader - an approach to extractive question answering with the same performance and significantly lower computational complexity than previous methods. Many popular models like Bidirectional Attention Flow use expensive attention mechanisms, and others like the Match-LSTM explicitly score all possible answers. In constrast, the GNR casts question answering as a search problem and applies a learning to search framework to solve it. The resulting model is 20x faster than Bi-Directional Attention flow and is the 2nd highest ranked model on the Stanford Question Answering (SQUAD) dev set.          
 
 <h3> 
 <a href="http://svail.github.io/DeepBench-update/" Onclick="_gaq.push(['trackEvent','Outbound’,'DeepBench-update',’svail.github.io/DeepBench-update',true]);" >DeepBench updates with a focus on deep learning inference</a>


### PR DESCRIPTION
Blog entry to accompany our EMNLP 2017 paper, Globally Normalized Reader. The associated blog post is currently on the internal github as `gnr_blog`. Before merging this PR, we should transfer the blog to `svail/GloballyNormalizedReader`. 